### PR TITLE
Sam/cusomter success

### DIFF
--- a/web/src/components/ad/ad.js
+++ b/web/src/components/ad/ad.js
@@ -1,7 +1,5 @@
 import React from 'react'
-
 import anthosVidBg from '../images/anthos/anthos-vid-bg.jpg'
-
 import styles from './ad.module.css'
 
 export default function ApplicationDevelopment ({data}) {
@@ -20,6 +18,7 @@ export default function ApplicationDevelopment ({data}) {
           </div>
         </div>
       ))}
+
     </div>
   )
 }

--- a/web/src/components/blog-post-preview.js
+++ b/web/src/components/blog-post-preview.js
@@ -3,7 +3,6 @@ import React from 'react'
 import {Link} from 'gatsby'
 import {getBlogUrl} from '../lib/helpers'
 import PortableText from './portableText'
-
 import styles from './blog-post-preview.module.css'
 
 function BlogPostPreview (props) {

--- a/web/src/components/customer-success/CustomerStories.js
+++ b/web/src/components/customer-success/CustomerStories.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import BlogPostPreview from '../blog-post-preview'
+import styles from './customer-success.module.css'
+
+export default function CustomerStories (props) {
+  return (
+    <div className={styles.root}>
+      <ul className={styles.grid}>
+        {props.nodes &&
+          props.nodes.slice(0, 3).map((node) => (
+            <li key={node.id} datacat={node.categories[0].title}>
+              <BlogPostPreview {...node} />
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}
+
+CustomerStories.defaultProps = {
+  nodes: []
+}

--- a/web/src/components/customer-success/customer-success.module.css
+++ b/web/src/components/customer-success/customer-success.module.css
@@ -1,0 +1,54 @@
+@import "../../styles/custom-media.css";
+@import "../../styles/custom-properties.css";
+
+.headline {
+  font-size: var(--font-micro-size);
+  line-height: var(--font-micro-line-height);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 2rem 0;
+}
+
+.grid {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-gap: 22px;
+  grid-auto-rows: 1fr;
+  margin-bottom: 80px;
+
+  @media (--media-min-small) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (--media-max-small) {
+    margin-bottom: 50px;
+  }
+
+  @media (--media-min-medium) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.grid li {
+  background: linear-gradient(#95d5d4, #dddfe4);
+}
+
+.grid li:hover {
+  box-shadow: 10px 10px 25px 0 rgba(0, 0, 0, 0.1);
+}
+
+.grid li[datacat="Case Study"] {
+  background: linear-gradient(#95d5d4, #dddfe4);
+}
+
+.grid li[datacat="News"] {
+  background: linear-gradient(#e5897f, #dddfe4);
+}
+
+.grid li[datacat="Blog"] {
+  background: linear-gradient(#7e97ad, #dddfe4);
+}

--- a/web/src/pages/ad.js
+++ b/web/src/pages/ad.js
@@ -4,15 +4,25 @@ import {graphql} from 'gatsby'
 import Layout from '../containers/layout'
 import SEO from '../components/seo'
 import ApplicationDevelopment from '../components/ad/ad'
+import CustomerStories from '../components/customer-success/CustomerStories'
+import {mapEdgesToNodes} from '../lib/helpers'
+import Container from '../components/container'
+import styles from '../components/layout.module.css'
 
-const Anthos = (props) => {
+export default function AppDev (props) {
   const {data} = props
   const siteSeo = (data || {}).siteSeo
+  const postNodes = data && data.posts && mapEdgesToNodes(data.posts)
 
   return (
     <Layout darkMode>
       <SEO title={siteSeo.seoTitle} description={siteSeo.seoDescription} />
       <ApplicationDevelopment data={data.overview.edges} />
+      <Container>
+        <p className={styles.subHeader}>Read about our successes</p>
+        <h1>Success Stories</h1>
+        {postNodes && postNodes.length && <CustomerStories nodes={postNodes} />}
+      </Container>
     </Layout>
   )
 }
@@ -54,7 +64,25 @@ export const query = graphql`
         }
       }
     }
+    posts: allSanityPost(
+    sort: {fields: [publishedAt], order: DESC}
+    filter: {slug: {current: {ne: null}}, publishedAt: {ne: null}}
+  ) {
+    edges {
+      node {
+        id
+        publishedAt
+        categories {
+          id
+          title
+        }
+        title
+        _rawExcerpt
+        slug {
+          current
+        }
+      }
+    }
+  }
   }
 `
-
-export default Anthos


### PR DESCRIPTION
Changes:

- Using the blog post component as a base, we can share customer stories on the AD page.
- Will wire this up in Sanity on my next PR to pull from a new "folder" that matches the blog entries, unless told otherwise
- This will get refactored later; just wanted to add some content to the page as a demonstration for feedback
- This PR also fixes some strange formatting and changes an error in previous PR dealing with the AD page